### PR TITLE
Add Pivotal Tracker public backlogs reference page

### DIFF
--- a/agile-resources/pivotal-tracker-public-backlogs.md
+++ b/agile-resources/pivotal-tracker-public-backlogs.md
@@ -1,0 +1,21 @@
+---
+title: Pivotal Tracker Public Backlog archive
+layout: default
+parent: Agile Resources
+---
+
+# List of surviving public Pivotal Tracker projects
+
+- <https://www.pivotaltracker.com/community/public-projects> has been taken down, but I trawled the Wayback Machine to find what surviving public projects I could, in the hope that the data enshrined in those backlogs might be useful.
+
+> **Note:** The archive ZIP files for these projects are large (50-60MB each) and will be added separately by repository maintainers. Due to GitHub LFS storage limitations in forks, they cannot be included in this PR.
+
+| Name                                        | Url                                                    | Archive Filename                                        |
+|---------------------------------------------|--------------------------------------------------------|---------------------------------------------------------|
+| CF BOSH Director (Public)                   | [Link](https://www.pivotaltracker.com/projects/956238) | cf_bosh_director_20250324_144303-export.zip (58 MB)     |
+| Concord.org Lab (Public)                    | [Link](https://www.pivotaltracker.com/projects/442903) | lab_20250324_144639-export.zip                          |
+| Gov.uk Departments and policy (Dev)(Public) | [Link](https://www.pivotaltracker.com/projects/367813) | departments_and_policy__dev__20250324_145531-export.zip |
+| growstuff (Public)                          | [Link](https://www.pivotaltracker.com/projects/646869) | growstuff_20250324_145411-export.zip                    |
+| Jasmine webOS(Public)                       | [Link](https://www.pivotaltracker.com/projects/16931)  | jasmine_webos_20250322_143837-export.zip                |
+| Jasmine(Public)                             | [Link](https://www.pivotaltracker.com/projects/10606)  | jasmine_20250321_173655-export.zip                      |
+| Siegegames Crea(Public)                     | [Link](https://www.pivotaltracker.com/projects/510733) | crea_20250324_144627-export.zip                         |


### PR DESCRIPTION
Add a page preserving Pivotal Tracker backlogs that were available publicly and have been archived.

The large ZIP files (50-60MB each) need to be added separately by repository maintainers due to GitHub LFS storage limitations in forks.