### PR TITLE
Add Rectangle window manager

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -21,3 +21,6 @@ There are dozens of these in the wild, but with the advent of Apple Silicon, man
       - `brew install --cask fertigt-slate`
     - [Intel Slate](https://github.com/mattr-/slate) - deprecated b/c of Apple Silicon
       - `brew install --cask mattr-slate`
+- [Rectangle](https://github.com/rxhanson/Rectangle)
+  - Similar to ShiftIt. Actively maintained.
+  - `brew install --cask rectangle`


### PR DESCRIPTION
Adding Rectangle to the Window Manager Tools list. It's become my go-to since ShiftIt didn't make the leap to Apple Silicon.